### PR TITLE
Fix error when model included mxpath call  with more than one label.

### DIFF
--- a/R/umxDoCbyPath.R
+++ b/R/umxDoCbyPath.R
@@ -495,8 +495,8 @@ xmu_path2twin <- function(paths, thisTwin = 1, sep = "_T"){
 		thisPath = paths[[i]]
 		thisPath@from = xmu_path_regex(thisPath$from, "$", suffix)
 		thisPath@to   = xmu_path_regex(thisPath$to  , "$", suffix)
-	        if (grepl("^data.", thisPath@labels)) {
-      			thisPath@labels = xmu_path_regex(thisPath@labels, "$", paste0(thisPath$label, suffix))
+    		if (any(grepl("^data\\.", thisPath@labels))) {
+      			thisPath@labels = xmu_path_regex(thisPath@labels, "$", suffix)
     		}
 		paths[[i]] = thisPath
 	}


### PR DESCRIPTION
Previous change didn't fix issue when a path had more than one label. Now I improved the regex to be more precise and check for any matches in list. This should cover all situations.