### PR TITLE
options(mxByrow = TRUE) side effects, removed

### DIFF
--- a/R/umxMatrixFree.R
+++ b/R/umxMatrixFree.R
@@ -35,9 +35,7 @@
 #'  # Will return a umxMatrix free at the eb2 and es2 positions.
 #'}
 
-umxMatrixFree  <- function (name = name, nrow = NULL, ncol = NA, free = FALSE, values = NA, labels = labels, ...){
-  
-  options(mxByrow = TRUE)
+umxMatrixFree  <- function (name = name, nrow = NULL, ncol = NA, free = FALSE, values = NA, labels = labels, byrow = TRUE, ...){
   
   if (missing(nrow)) {
     if (!missing(free)) {nrow = dim(matrix(free, ncol = ncol))[1]}

--- a/R/umxMatrixFree.R
+++ b/R/umxMatrixFree.R
@@ -35,7 +35,8 @@
 #'  # Will return a umxMatrix free at the eb2 and es2 positions.
 #'}
 
-umxMatrixFree  <- function (name = name, nrow = NULL, ncol = NA, free = FALSE, values = NA, labels = labels, byrow = TRUE, ...){
+umxMatrixFree  <- function (name = name, nrow = NULL, ncol = NA, free = FALSE, values = NA, labels = labels, byrow = TRUE,...){
+  
   
   if (missing(nrow)) {
     if (!missing(free)) {nrow = dim(matrix(free, ncol = ncol))[1]}
@@ -44,7 +45,6 @@ umxMatrixFree  <- function (name = name, nrow = NULL, ncol = NA, free = FALSE, v
   }
   
   if (!missing(labels)) {
-    labels. = labels
     free = labels
     free = (!is.na(labels))
   }
@@ -52,7 +52,7 @@ umxMatrixFree  <- function (name = name, nrow = NULL, ncol = NA, free = FALSE, v
   dots <- list(...)
   do.call(eval(parse(
     text="umx::umxMatrix")),
-    c(list(name = name, nrow = nrow, ncol = ncol, free = free ,values = values, labels = labels),
+    c(list(name = name, nrow = nrow, ncol = ncol, free = free ,values = values, labels = labels, byrow = byrow),
       dots[names(dots)])
   )
 }


### PR DESCRIPTION
Learned the hard way about side effects of the options() function. This line is not kept within the function namespace, it would affect, eg, umxThresholds if run after it. Rookie mistake, sorry.