### PR TITLE
Compatibility with ggplot2 3.6.0

### DIFF
--- a/R/umxDoC.R
+++ b/R/umxDoC.R
@@ -75,7 +75,7 @@ umxDiffMZ <- function(x, y, data, sep = "_T", mzZygs = c("MZFF", "MZMM"), zyg = 
 	R2     = round(sumry$r.squared, 3)
 	pvalStr = paste0(", p ", umxAPA(pvalue, addComparison = TRUE, digits = digits, report = "none"))
 	blurb  = umxAPA(beta, se=SE, report = "expression", suffix = pvalStr)
-	p = p + annotate("text", x = labxy[1], y = labxy[2], label = blurb)
+	p = p + annotate("text", x = labxy[1], y = labxy[2], label = deparse(blurb), parse = TRUE)
 	p = p + theme_bw() # + hrbrthemes::theme_ipsum()
 	print(p)
 }


### PR DESCRIPTION
Hi there,

Apologies for not posting an issue first.
The ggplot2 package is planning an update for around May 2025 and a reverse dependency test identified a problem with the umx package.
The details are explained in https://github.com/tidyverse/ggplot2/issues/6294, but essentially ggplot2 don't accept expressions as labels and we're becoming more strict about this.
This PR changes a label to no longer be an expression.
You can test the changes yourself with the development version of ggplot2 (`pak::pak("tidyverse/ggplot2")`)

Best,
Teun